### PR TITLE
Use AQandU instead of LRAPA

### DIFF
--- a/app.js
+++ b/app.js
@@ -42,7 +42,7 @@
       pm25s.push(parseFloat(subsensor["PM2_5Value"]))
     }
     const pm25 = (pm25s.reduce((a, b) => a + b)) / pm25s.length
-    const aqi = lrapaAQIFromPM(pm25)
+    const aqi = aqanduAQIFromPM(pm25)
 
     const distance = Math.round(closestSensor.distance * 10) / 10
     const time = (new Date()).toLocaleTimeString()
@@ -106,8 +106,8 @@
     return `https://www.purpleair.com/map?opt=1/i/mAQI/a10/cC4&select=${closestSensor.id}#14/${coord.latitude}/${coord.longitude}`
   }
 
-  function lrapaAQIFromPM(pm) {
-    return aqiFromPM(0.5 * pm - 0.66)
+  function aqanduAQIFromPM(pm) {
+    return aqiFromPM(0.778 * pm + 2.65)
   }
 
   function aqiFromPM(pm) {

--- a/app.js
+++ b/app.js
@@ -103,7 +103,7 @@
   }
 
   function getPurpleAirLink() {
-    return `https://www.purpleair.com/map?opt=1/i/mAQI/a10/cC4&select=${closestSensor.id}#14/${coord.latitude}/${coord.longitude}`
+    return `https://www.purpleair.com/map?opt=1/i/mAQI/a0/cC1&select=${closestSensor.id}#14/${coord.latitude}/${coord.longitude}`
   }
 
   function aqanduAQIFromPM(pm) {


### PR DESCRIPTION
Seems the [popular article that recommended LRAPA](https://thebolditalic.com/understanding-purpleair-vs-airnow-gov-measurements-of-wood-smoke-pollution-562923a55226) is now pushing AQandU as even better, so lets use that!