### PR TITLE
fix header tags not being closed right, center text in browser window

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,9 +31,11 @@
     <link rel="manifest" href="/site.webmanifest">
   </head>
   <body class="checking">
-    <h1 id="aqi">Checking&hellip;</h1>
-    <h2 id="desc"></h2>
-    <h3 id="msg"></h2>
-    <h4 id="sensor"></h2>
+    <div>
+        <h1 id="aqi">Checking&hellip;</h1>
+        <h2 id="desc"></h2>
+        <h3 id="msg"></h3>
+        <h4 id="sensor"></h4>
+    </div>
   </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -1,5 +1,9 @@
 body {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+  min-height: 100vh;
+  display: grid;
+  justify-items: center;
+  align-items: center;
 }
 
 h1, h2, h3, h4 {


### PR DESCRIPTION
minor front end tweaks, I didn't extensively test, but centers the output in the browser window (taste thing) and closed the h3 and h4 tag correctly

<img width="1434" alt="Screen Shot 2020-09-06 at 3 09 26 PM" src="https://user-images.githubusercontent.com/1466460/92336196-fbc1fb80-f052-11ea-85e7-6fb02345261d.png">
