### PR TITLE
Switch to a variant of the options used by the purpleair map when fetching data.json

### DIFF
--- a/app.js
+++ b/app.js
@@ -14,7 +14,7 @@
 
     announce("Finding nearby sensors")
 
-    const url = "https://www.purpleair.com/data.json"
+    const url = "https://www.purpleair.com/data.json?opt=1/mAQI/a10/cC0&fetch=true&fields=,"
 
     window.fetch(url)
       .then(response => response.json())


### PR DESCRIPTION

The version we used before fetched approximately 640k of data. This fetches about 260k of data. That's still pretty nutty when we're just trying to find the nearest sensor. But it's a lot friendlier on users network stacks and purpleair's servers