### PR TITLE
Ignore stale sensors

### DIFF
--- a/app.js
+++ b/app.js
@@ -95,8 +95,10 @@
     fields["latitude"] = json.fields.findIndex(e => e === "Lat")
     fields["longitude"] = json.fields.findIndex(e => e === "Lon")
     fields["id"] = json.fields.findIndex(e => e === "ID")
+    fields["age"] = json.fields.findIndex(e => e === "age")
     for(const sensor of json.data) {
-      if(sensor[fields["indoor"]] === 0) {
+      // Ignore sensors which are either indoor or updated over 5 minutes ago
+      if(sensor[fields["indoor"]] === 0 && sensor[fields["age"]] < 5) {
         sensors.push({
           id: sensor[fields["id"]],
           latitude: sensor[fields["latitude"]],


### PR DESCRIPTION
Looks like filtering out old sensors was pretty straight forward. The API includes an `age` field with last update time in minutes, so lets use that to filter out old sensors!

---

Closes https://github.com/skalnik/aqi-wtf/issues/18.