### PR TITLE
Simplify title for Progressive Web Apps

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html lang="en">
   <head>
-    <title>What the fuck is the AQI</title>
+    <title>AQI WTF?!</title>
     <script type="text/javascript" src="app.js"></script>
     <link rel="stylesheet" href="style.css" />
     <script async defer data-domain="aqiwtf.com" src="https://plausible.io/js/plausible.js"></script>


### PR DESCRIPTION
When saving this to your iOS home screen as a progressive web app, the title is extremely long and gets cut off. Trying to fix that here!

![](https://i.imgur.com/wi5qo1I.jpg)