### PR TITLE
Reload less frequently

### DIFF
--- a/app.js
+++ b/app.js
@@ -66,7 +66,7 @@
 
     body.classList.remove(...body.classList)
     body.classList.add(getAQIClass(aqi))
-    setTimeout(() => updateWithSensor(closestSensor), 30000);
+    setTimeout(() => updateWithSensor(closestSensor), 60000);
   }
 
   function announce(message) {


### PR DESCRIPTION
In an attempt to help with https://github.com/skalnik/aqi-wtf/issues/22, this increases the time we refresh from a sensor to once a minute. I don't think the sensors update any more frequently than that anyway, so shouldn't cause any problems