### PR TITLE
Small text tweaks

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,14 +13,13 @@
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://aqiwtf.com/">
-    <meta property="og:title" content="What the fuck is the AQI">
+    <meta property="og:title" content="AQI WTF?!">
     <meta property="og:description" content="What the fuck is the AQI from the nearest Purple Air sensor to me?">
     <meta property="og:image" content="meta.png">
 
     <!-- Twitter -->
-    <meta property="twitter:card" content="summary_large_image">
     <meta property="twitter:url" content="https://aqiwtf.com/">
-    <meta property="twitter:title" content="What the fuck is the AQI">
+    <meta property="twitter:title" content="AQI WTF?!">
     <meta property="twitter:description" content="What the fuck is the AQI from the nearest Purple Air sensor to me?">
     <meta property="twitter:image" content="meta.png">
 

--- a/index.html
+++ b/index.html
@@ -38,7 +38,7 @@
         <h4 id="sensor"></h4>
         <footer>
           Created by <a href="https://skalnik.com">Mike Skalnik</a> &amp; <a href="https://github.com/skalnik/aqi-wtf/graphs/contributors">friends<a> using data from <a href="https://www.purpleair.com">Purple Air</a>.
-          <a href="https://github.com/skalnik/aqi-wtf">Found a bug?</a>
+          <a href="https://github.com/skalnik/aqi-wtf">Found a &#x1F41B?</a>
       </footer>
     </div>
   </body>


### PR DESCRIPTION
This PR adjusts the metadata title to match the current page title, and replace `bug` with `🐛` in the footer.