### PR TITLE
Add a reload link on error

### DIFF
--- a/app.js
+++ b/app.js
@@ -219,6 +219,6 @@
 
   function purpleError(error) {
     console.error("Purple Air Error: ", error)
-    announce("idk how purple air evens, m8", error);
+    announce("idk how purple air evens, m8", error, `<a href="#" onclick="location.reload()">Reload?</a>`)
   }
 })();


### PR DESCRIPTION
Adds a simple reload link when we hit an error. We could do smarter, but this is a bare minimum.

<img width="1059" alt="Screen Shot 2020-09-07 at 7 16 57 PM" src="https://user-images.githubusercontent.com/2546/92426410-b67af800-f13e-11ea-95dc-9621f19034c3.png">


---

Closes https://github.com/skalnik/aqi-wtf/issues/31