### PR TITLE
Locate the user on every refresh.

### DIFF
--- a/app.js
+++ b/app.js
@@ -12,14 +12,14 @@
 
 
   function getLocation() {
-    announce("Finding you");
+    announceState("Finding you");
     navigator.geolocation.getCurrentPosition(located, unsupported);
   }
 
   function located(position) {
     coord = position.coords;
 
-    announce("Finding nearby sensors");
+    announceState("Finding nearby sensors");
     loadSensorsFromCacheAndShowAQI();
   }
  
@@ -68,7 +68,7 @@
   }
 
   function updateWithSensor(sensor) {
-    announce("Getting sensor data");
+    announceState("Getting sensor data");
     const url = `https://www.purpleair.com/json?show=${sensor.id}`;
 
     window
@@ -81,7 +81,7 @@
   function updateAQI(sensor) {
     let pm25s = [];
 
-    announce("Calculating AQI");
+    announceState("Calculating AQI");
 
     for (const subsensor of sensor.results) {
       pm25s.push(parseFloat(subsensor["PM2_5Value"]));
@@ -114,6 +114,20 @@
     desc.innerHTML = descMsg;
     msg.innerHTML = msgMsg;
     state.innerHTML = stateMsg;
+  }
+  
+  function announceState(stateMsg) {
+    // If we have something in state already, it means we've previously loaded
+    // some content and don't want to blow away the top level AQI state until
+    // we have something interesting to report
+    if (state.innerHTML !== "") { 
+      const state = document.getElementById("state");
+      state.innerHTML = stateMsg;
+    } else {
+      // If state is empty, we have not yet given the breather an AQI reading, so 
+      // state is important enough to shove up top in the H1
+      announce(stateMsg);
+    }
   }
 
   function findClosestSensor(sensors) {

--- a/app.js
+++ b/app.js
@@ -93,9 +93,9 @@
     const time = new Date().toLocaleTimeString();
     const paLink = getPurpleAirLink();
     const aqiMsg = `AQI is ${aqi} ${getAQIEmoji(aqi)}`;
-    const sensorMsg = `From <a href="${paLink}">a sensor ${distance}km away</a>  at ${time}`;
+    const stateMsg = `From <a href="${paLink}">a sensor ${distance}km away</a>  at ${time}`;
 
-    announce(aqiMsg, getAQIDescription(aqi), getAQIMessage(aqi), sensorMsg);
+    announce(aqiMsg, getAQIDescription(aqi), getAQIMessage(aqi), stateMsg);
 
     const body = document.querySelector("body");
     body.classList.remove(...body.classList);
@@ -104,16 +104,16 @@
     setTimeout(() => getLocation(), 60000);
   }
 
-  function announce(headMsg, descMsg = "", msgMsg = "", sensorMsg = "") {
+  function announce(headMsg, descMsg = "", msgMsg = "", stateMsg = "") {
     const head = document.getElementById("aqi");
     const desc = document.getElementById("desc");
     const msg = document.getElementById("msg");
-    const sensor = document.getElementById("sensor");
+    const state = document.getElementById("state");
 
     head.innerHTML = headMsg;
     desc.innerHTML = descMsg;
     msg.innerHTML = msgMsg;
-    sensor.innerHTML = sensorMsg;
+    state.innerHTML = stateMsg;
   }
 
   function findClosestSensor(sensors) {

--- a/app.js
+++ b/app.js
@@ -101,7 +101,7 @@
     body.classList.remove(...body.classList);
     body.classList.add(getAQIClass(aqi));
 
-    setTimeout(() => updateWithSensor(closestSensor), 60000);
+    setTimeout(() => getLocation(), 60000);
   }
 
   function announce(headMsg, descMsg = "", msgMsg = "", sensorMsg = "") {

--- a/index.html
+++ b/index.html
@@ -34,7 +34,7 @@
         <h1 id="aqi">Checking&hellip;</h1>
         <h2 id="desc"></h2>
         <h3 id="msg"></h3>
-        <h4 id="sensor"></h4>
+        <h4 id="state"></h4>
         <footer>
           Created by <a href="https://skalnik.com">Mike Skalnik</a> &amp; <a href="https://github.com/skalnik/aqi-wtf/graphs/contributors">friends<a> using data from <a href="https://www.purpleair.com">Purple Air</a>.
           <a href="https://github.com/skalnik/aqi-wtf">Found a &#x1F41B?</a>


### PR DESCRIPTION
As part of this change, status messages on refresh no longer blow away the AQI number, since they're not helpful to the user.

Fixes #29 

I'll pop in again in after work today.