### PR TITLE
Update app.js

### DIFF
--- a/app.js
+++ b/app.js
@@ -27,6 +27,9 @@
     try {
       const cachedSensors = window.localStorage.getItem("sensors");
       sensor_data = JSON.parse(cachedSensors);
+      if (sensor_data == null) {
+        throw "Sensor data not cached";
+      }
       if (sensor_data.version !== 1) {
         throw "Sensor data is the wrong version";
       }


### PR DESCRIPTION
An exception is thrown when calling `loadSensorsFromCacheAndShowAQI` if no sensor data is stored locally.