### PR TITLE
Fix broken sensor averaging

### DIFF
--- a/app.js
+++ b/app.js
@@ -86,7 +86,9 @@
     announceState("Calculating AQI");
 
     for (const subsensor of sensor.results) {
-      pm25s.push(parseFloat(subsensor["PM2_5Value"]));
+      if (!bustedSensor(subsensor)) {
+        pm25s.push(parseFloat(subsensor["PM2_5Value"]));
+      }
     }
     const pm25 = pm25s.reduce((a, b) => a + b) / pm25s.length;
     const aqi = aqanduAQIFromPM(pm25);
@@ -104,6 +106,32 @@
     body.classList.add(getAQIClass(aqi));
 
     setTimeout(() => getLocation(), 60000);
+  }
+
+  function bustedSensor(sensor) {
+    const pValues = [
+      "p_0_3_um",
+      "p_0_5_um",
+      "p_1_0_um",
+      "p_2_5_um",
+      "p_5_0_um",
+      "p_10_0_um",
+      "pm1_0_cf_1",
+      "pm2_5_cf_1",
+      "pm10_0_cf_1",
+      "pm1_0_atm",
+      "pm2_5_atm",
+      "pm10_0_atm",
+    ];
+    let busted = true;
+
+    for (const pValue of pValues) {
+      if (sensor[pValue] !== "0.0") {
+        return false;
+      }
+    }
+
+    return true;
   }
 
   function announce(headMsg, descMsg = "", msgMsg = "", stateMsg = "") {


### PR DESCRIPTION
This PR attempts to setup some basic broken sensor detection but seeing if all the extra pm values are zero, and if so, ignoring that sensor in the sensor pair. This could be made smarter by checking if *both* pairs in the sensor are all zero and then ignoring that sensor all together and finding the next one, but this seems like a good start.