### PR TITLE
Switch to more actionable explanations of the air quality badness.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@ I got tired of checking [PurpleAir](http://purpleair.com/map) all the time to
 see the AQI near me, so I wrote this. It uses their API, finds the nearest
 sensor, and displays the AQandU adjusted AQI information.
 
+### AQI level descriptions
+
+Descriptions about who should be concerned about the current AQI come EPA report EPA-456/F-15-005 retrieved from 
+https://www.airnow.gov/sites/default/files/2018-04/air-quality-guide_pm_2015_0.pdf on September 11, 2020
+
 
 ### Feature Matrix
 

--- a/app.js
+++ b/app.js
@@ -99,7 +99,7 @@
     const aqiMsg = `AQI is ${aqi} ${getAQIEmoji(aqi)}`;
     const stateMsg = `From <a href="${paLink}">a sensor ${distance}km away</a>  at ${time}`;
 
-    announce(aqiMsg, getAQIDescription(aqi), getAQIMessage(aqi), stateMsg);
+    announce(aqiMsg, getAQIDescription(aqi), stateMsg);
 
     const body = document.querySelector("body");
     body.classList.remove(...body.classList);
@@ -134,15 +134,13 @@
     return true;
   }
 
-  function announce(headMsg, descMsg = "", msgMsg = "", stateMsg = "") {
+  function announce(headMsg, descMsg = "", stateMsg = "") {
     const head = document.getElementById("aqi");
     const desc = document.getElementById("desc");
-    const msg = document.getElementById("msg");
     const state = document.getElementById("state");
 
     head.innerHTML = headMsg;
     desc.innerHTML = descMsg;
-    msg.innerHTML = msgMsg;
     state.innerHTML = stateMsg;
   }
 
@@ -295,27 +293,6 @@
     }
   }
 
-  function getAQIMessage(aqi) {
-    if (aqi == 420) {
-      return "Blaze it! Everyone may experience more serious health effects";
-    } else if (aqi >= 401) {
-      return "Health alert: everyone may experience more serious health effects";
-    } else if (aqi >= 301) {
-      return "Health alert: everyone may experience more serious health effects";
-    } else if (aqi >= 201) {
-      return "Health warnings of emergency conditions. The entire population is more likely to be affected. ";
-    } else if (aqi >= 151) {
-      return "Everyone may begin to experience health effects; members of sensitive groups may experience more serious health effects.";
-    } else if (aqi >= 101) {
-      return "Members of sensitive groups may experience health effects. The general public is not likely to be affected.";
-    } else if (aqi >= 51) {
-      return "Air quality is acceptable; however, for some pollutants there may be a moderate health concern for a very small number of people who are unusually sensitive to air pollution.";
-    } else if (aqi >= 0) {
-      return "Air quality is considered satisfactory, and air pollution poses little or no risk";
-    } else {
-      return undefined;
-    }
-  }
 
   function unsupported() {
     announce("Couldn't locate ya or ya got an unsupported browser, chief");

--- a/index.html
+++ b/index.html
@@ -37,6 +37,7 @@
         <h1 id="aqi">Checking&hellip;</h1>
         <h2 id="desc"></h2>
         <h3 id="msg"></h3>
+        <h4 id="state"></h4>
 
 <div class="explanation very-hazardous">
 
@@ -84,7 +85,6 @@ signs to take it easier.</p>
 <div class="explanation good">
 <p>It’s a great day to be active outside.</p>
 </div>
-        <h4 id="state"></h4>
       </div>
     </div>
     <footer>

--- a/index.html
+++ b/index.html
@@ -37,6 +37,53 @@
         <h1 id="aqi">Checking&hellip;</h1>
         <h2 id="desc"></h2>
         <h3 id="msg"></h3>
+
+<div class="explanation very-hazardous">
+
+</div>
+<div class="explanation hazardous">
+<p><b>Everyone</b>: Avoid all physical activity outdoors.</p>
+<p><b>Sensitive groups</b>: Remain indoors and keep activity
+levels low. Follow tips for keeping particle levels low
+indoors.</p>
+</div>
+<div class="explanation very-unhealthy">
+<p><b>Sensitive groups</b>: Avoid all physical activity outdoors.
+Move activities indoors or reschedule to a time when
+air quality is better.</p>
+<p><b>Everyone else</b>: Avoid prolonged or heavy exertion.
+Consider moving activities indoors or rescheduling to
+a time when air quality is better.</p>
+</div>
+<div class="explanation unhealthy">
+<p><b>Sensitive groups</b>: Avoid prolonged or heavy exertion.
+Consider moving activities indoors or rescheduling.</p>
+<p><b>Everyone else</b>: Reduce prolonged or heavy exertion.
+Take more breaks during outdoor activities.</p>
+</div>
+<div class="explanation unhealthy-for-sensitive-groups">
+<p><b>Sensitive groups</b>: Reduce prolonged or heavy
+exertion. It’s OK to be active outside, but take more
+breaks and do less intense activities. Watch for
+symptoms such as coughing or shortness of breath.</p>
+<p><b>People with asthma</b>: should follow their asthma
+action plans and keep quick relief medicine handy.</p>
+<p><b>If you have heart disease</b>: Symptoms such as
+palpitations, shortness of breath, or unusual fatigue
+may indicate a serious problem. If you have any of
+these, contact your heath care provider.
+</p>
+</div>
+<div class="explanation moderate">
+<p><b>Unusually sensitive people</b>: Consider reducing
+prolonged or heavy exertion. Watch for symptoms
+such as coughing or shortness of breath. These are
+signs to take it easier.</p>
+<p><b>Everyone else</b>: It’s a good day to be active outside.</p>
+</div>
+<div class="explanation good">
+<p>It’s a great day to be active outside.</p>
+</div>
         <h4 id="state"></h4>
       </div>
     </div>

--- a/style.css
+++ b/style.css
@@ -71,9 +71,40 @@ body.very-hazardous {
   color: #FFF;
 }
 
+body .explanation {
+	display: none;
+}
+
+body.very-hazardous .explanation.very-hazardous {
+	display: block;
+}
+body.hazardous .explanation.hazardous {
+	display: block;
+}
+
+body.very-unhealthy .explanation.very-unhealthy {
+	display: block;
+}
+body.unhealthy .explanation.unhealthy {
+	display: block;
+}
+
+body.unhealthy-for-sensitive-groups .explanation.unhealthy-for-sensitive-groups {
+	display: block;
+}
+
+body.moderate .explanation.moderate {
+	display: block;
+}
+
+body.good .explanation.good {
+	display: block;
+}
+
 a {
   color: inherit;
 }
+
 
 footer {
   flex-shrink: 0;


### PR DESCRIPTION
These explanations from an EPA publication found at https://www.airnow.gov/sites/default/files/2019-02/air-quality-guide_pm_2015.pdf and are the most "actionable" version of the explanations.

Additionally, move the prose descriptions into the HTML and toggle them on and off with CSS. This cuts down the strings in the HTML, reduces the amount of manual DOM twiddling we need to do and reduces the chance that our various tables of the differing levels of badness will get out of sync.

I'm gonna stop messing around for now.
