### PR TITLE
Fix emoji in very hazardous rating

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,7 +35,7 @@
       <div>
         <h1>
           <span id="aqi">Checking&hellip;</span>
-          <span class="maybe-show airmoji very-hazardous">&#x2620;</span>
+          <span class="maybe-show airmoji very-hazardous">&#x2620;&#65039;</span>
           <span class="maybe-show airmoji hazardous">&#x1F635;</span>
           <span class="maybe-show airmoji very-unhealthy">&#x1F922;</span>
           <span class="maybe-show airmoji unhealthy">&#x1F637;</span>


### PR DESCRIPTION
Fixes a small bug I noticed when testing other PRs. Adds the emoji forcing character to the Very Hazardous emoji.

Before:
<img width="984" alt="Screen Shot 2020-09-12 at 2 08 57 PM" src="https://user-images.githubusercontent.com/2546/93005057-2522d180-f502-11ea-9b2f-9bca5d878e06.png">

After:
<img width="984" alt="Screen Shot 2020-09-12 at 2 08 08 PM" src="https://user-images.githubusercontent.com/2546/93005060-2d7b0c80-f502-11ea-9f33-1c8dc5510e06.png">
