### PR TITLE
Switch AQI calculations to use the EPA recommended corrections for PA Sensors.

### DIFF
--- a/app.js
+++ b/app.js
@@ -259,7 +259,7 @@
   }
 
   function epaAQIFromPMandHumidity(pm, humidity) {
-    return aqiFromPM((0.543*pm) - (0.0844*humidity) + 5.604);
+    return aqiFromPM((0.534*pm) - (0.0844*humidity) + 5.604);
   }
 	
 

--- a/app.js
+++ b/app.js
@@ -251,7 +251,7 @@
   }
 
   function getPurpleAirLink() {
-    return `https://www.purpleair.com/map?opt=1/i/mAQI/a0/cC1&select=${closestSensor.id}#14/${coord.latitude}/${coord.longitude}`;
+    return `https://www.purpleair.com/map?opt=1/i/mAQI/a0/cC5&select=${closestSensor.id}#14/${coord.latitude}/${coord.longitude}`;
   }
 
   function aqanduAQIFromPM(pm) {

--- a/app.js
+++ b/app.js
@@ -85,17 +85,19 @@
 
   function updateAQI(sensor) {
     let pm25s = [];
+    let humidity = sensor.results[0].humidity;
 
     announceState("Calculating AQI");
 
     for (const subsensor of sensor.results) {
       if (!bustedSensor(subsensor)) {
-        pm25s.push(parseFloat(subsensor["PM2_5Value"]));
+        pm25s.push(parseFloat(subsensor["pm2_5_cf_1"]));
       }
+    
     }
     const pm25 = pm25s.reduce((a, b) => a + b) / pm25s.length;
-    const aqi = aqanduAQIFromPM(pm25);
-
+    const aqi = epaAQIFromPMandHumidity(pm25,humidity);
+ 
     const distance = Math.round(closestSensor.distance * 10) / 10;
     const time = new Date().toLocaleTimeString();
     const paLink = getPurpleAirLink();
@@ -227,6 +229,11 @@
   function aqanduAQIFromPM(pm) {
     return aqiFromPM(0.778 * pm + 2.65);
   }
+
+  function epaAQIFromPMandHumidity(pm, humidity) {
+    return aqiFromPM((0.543*pm) - (0.0844*humidity) + 5.604);
+  }
+	
 
   function aqiFromPM(pm) {
     if (isNaN(pm)) return "-";

--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
           <span class="maybe-show airmoji moderate">&#x1F610;</span>
           <span class="maybe-show airmoji good">&#x1F600;</span>
         </h1>
-        <div id="aqi-explanation">AQI calculated using <a href="https://thebolditalic.com/understanding-purpleair-vs-airnow-gov-measurements-of-wood-smoke-pollution-562923a55226">EPA-recommended corrections</a>.</div>
+        <div id="aqi-explanation">AQI calculated using <a href="https://thebolditalic.com/understanding-purpleair-vs-airnow-gov-measurements-of-wood-smoke-pollution-562923a55226">EPA-recommended corrections</a></div>
         <div id="state"></div>
         <h2> <span id="desc"></span>
           <span class="maybe-show aqi-desc very-hazardous">Very Hazardous</span>

--- a/index.html
+++ b/index.html
@@ -34,7 +34,7 @@
     <div class="container">
       <div>
         <h1 id="aqi">Checking&hellip;</h1>
-        <div id="aqi-explanation">AQI calculated with <a href="https://thebolditalic.com/understanding-purpleair-vs-airnow-gov-measurements-of-wood-smoke-pollution-562923a55226">AQandU normalization</a></div>
+        <div id="aqi-explanation">AQI calculated with <a href="https://thebolditalic.com/understanding-purpleair-vs-airnow-gov-measurements-of-wood-smoke-pollution-562923a55226">EPA-recommended corrections</a>.</div>
         <h2 id="desc"></h2>
         <h3 id="msg"></h3>
         <h4 id="state"></h4>


### PR DESCRIPTION
Please check this work CAREFULLY. 


As of this PR, we are -not- yet averaging across at least two minutes of readings and throwing a fit if values are off by more than 5% as recommended by them.

Sources:

https://thebolditalic.com/understanding-purpleair-vs-airnow-gov-measurements-of-wood-smoke-pollution-562923a55226
https://cfpub.epa.gov/si/si_public_record_report.cfm?dirEntryId=349513&Lab=CEMM&simplesearch=0&showcriteria=2&sortby=pubDate&timstype=&datebeginpublishedpresented=08/25/2018