### PR TITLE
Move the location permission request notice into HTML

### DIFF
--- a/app.js
+++ b/app.js
@@ -165,8 +165,8 @@
     // If we have something in state already, it means we've previously loaded
     // some content and don't want to blow away the top level AQI state until
     // we have something interesting to report
+    const state = document.getElementById("state");
     if (state.innerHTML !== "") {
-      const state = document.getElementById("state");
       state.innerHTML = stateMsg;
     } else {
       // If state is empty, we have not yet given the breather an AQI reading, so

--- a/app.js
+++ b/app.js
@@ -12,16 +12,18 @@
   }
 
   function getLocation() {
-    announceState(
-      "Finding you",
-      "We need your browser location to find the nearest PurpleAir sensor. This information never leaves your device. It's not sent to a server."
-    );
+    announceState( "Finding you");
+    // If we don't have a location yet, then this is the first time we're trying
+    // and we should explain ourselves
+    if (coord === undefined ) {
+      explainPermissionsRequest();
+    }
     navigator.geolocation.getCurrentPosition(located, unsupported);
   }
 
   function located(position) {
     coord = position.coords;
-
+    clearPermissionsRequest();
     announceState("Finding nearby sensors");
     loadSensorsFromCacheAndShowAQI();
   }
@@ -134,6 +136,17 @@
 
     return true;
   }
+  
+  function explainPermissionsRequest() {
+    const body = document.querySelector("body");
+    body.classList.add("requesting-location");
+  }
+
+  function clearPermissionsRequest() {
+    const body = document.querySelector("body");
+    body.classList.remove("requesting-location");
+
+  }
 
   function announce(headMsg, descMsg = "", stateMsg = "") {
     const head = document.getElementById("aqi");
@@ -161,7 +174,7 @@
     announce(errorMsg, descMsg, callToAction);
   }
 
-  function announceState(stateMsg, descMsg = "") {
+  function announceState(stateMsg) {
     // If we have something in state already, it means we've previously loaded
     // some content and don't want to blow away the top level AQI state until
     // we have something interesting to report
@@ -171,7 +184,7 @@
     } else {
       // If state is empty, we have not yet given the breather an AQI reading, so
       // state is important enough to shove up top in the H1
-      announce(stateMsg, descMsg);
+      announce(stateMsg);
     }
   }
 
@@ -288,6 +301,7 @@
   }
 
   function unsupported() {
+    clearPermissionsRequest();
     announceError(
       "Scooby-Doo, Where Are You!",
       "We need your browser location to find the nearest PurpleAir sensor. This information never leaves your device. It's not sent to a server."

--- a/index.html
+++ b/index.html
@@ -119,6 +119,10 @@
         <div class="explanation maybe-show good">
         <p>It’s a great day to be active outside.</p>
         </div>
+        <div id="explain-permissions">
+          We need your browser location to find the nearest PurpleAir sensor.
+          This information never leaves your device. It's not sent to a server.
+        </div>
       </div>
     </div>
     <footer>

--- a/style.css
+++ b/style.css
@@ -117,6 +117,15 @@ body.good .maybe-show.good {
 	display: revert;
 }
 
+
+body #explain-permissions {
+	display: none;
+}
+
+body.requesting-location #explain-permissions {
+	display: block;
+}
+
 a {
   color: inherit;
 }


### PR DESCRIPTION
Right now on iOS, the permissions request covers our explanation of why we're requesting the permissions.

This PR doesn't solve that problem, but it makes the eventual solution a CSS problem, rather than a JavaScript problem.