### PR TITLE
Center `good` description and CSS clean up

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
     "lint": "prettier *.js *.json",
-    "lint:fix": "prettier --write *.js *.json"
+    "lint:fix": "prettier --write *.js *.json *.css"
   },
   "devDependencies": {
     "prettier": "^2.1.1"

--- a/style.css
+++ b/style.css
@@ -88,43 +88,43 @@ body.very-hazardous {
 }
 
 body .maybe-show {
-	display: none;
+  display: none;
 }
 
 body.very-hazardous .maybe-show.very-hazardous {
-	display: revert;
+  display: revert;
 }
 body.hazardous .maybe-show.hazardous {
-	display: revert;
+  display: revert;
 }
 
 body.very-unhealthy .maybe-show.very-unhealthy {
-	display: revert;
+  display: revert;
 }
 body.unhealthy .maybe-show.unhealthy {
-	display: revert;
+  display: revert;
 }
 
 body.unhealthy-for-sensitive-groups .maybe-show.unhealthy-for-sensitive-groups {
-	display: revert;
+  display: revert;
 }
 
 body.moderate .maybe-show.moderate {
-	display: revert;
+  display: revert;
 }
 
 body.good .maybe-show.good {
   text-align: center;
-	display: revert;
+  display: revert;
 }
 
 
 body #explain-permissions {
-	display: none;
+  display: none;
 }
 
 body.requesting-location #explain-permissions {
-	display: block;
+  display: block;
 }
 
 a {

--- a/style.css
+++ b/style.css
@@ -114,6 +114,7 @@ body.moderate .maybe-show.moderate {
 }
 
 body.good .maybe-show.good {
+  text-align: center;
 	display: revert;
 }
 


### PR DESCRIPTION
I started this PR primarily to center the `good` description since it still seems odd to me that it's right aligned. Another great benefit of this living in HTML is we can style each of them independently super easily!

However, I then noticed we were mixing tabs and spaces in `style.css` so I moved over to spaces since that seems to be what Prettier uses and then updated the fixer to take over the CSS for us as well. I've played with using Prettier for HTML but it does some weird things I don't like, so I haven't enabled it for that yet. Maybe in the future if I can figure out how to make it stop doing silly things like:

```html
        <a href="https://github.com/skalnik/aqi-wtf/graphs/contributors"
          >friends</a
        >
```