### PR TITLE
Add metadata and offline storage to pass PWA check

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,6 +29,8 @@
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
     <link rel="manifest" href="/site.webmanifest">
+
+    <meta name="theme-color" content="#ffffff">
   </head>
   <body class="checking">
     <div class="container">

--- a/package.json
+++ b/package.json
@@ -5,5 +5,13 @@
   },
   "devDependencies": {
     "prettier": "^2.1.1"
+  },
+  "license": {
+    "type": "MIT",
+    "url": "https://www.opensource.org/licenses/mit-license.php"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/skalnik/aqi-wtf.git"
   }
 }

--- a/site.webmanifest
+++ b/site.webmanifest
@@ -1,1 +1,20 @@
-{"name":"","short_name":"","icons":[{"src":"/android-chrome-192x192.png","sizes":"192x192","type":"image/png"},{"src":"/android-chrome-512x512.png","sizes":"512x512","type":"image/png"}],"theme_color":"#ffffff","background_color":"#ffffff","display":"standalone"}
+{
+  "name": "WTF is the AQI?!",
+  "short_name": "AQI WTF?!",
+  "start_url": "/?mode=pwa",
+  "icons": [
+    {
+      "src": "/android-chrome-192x192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "/android-chrome-512x512.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ],
+  "theme_color": "#ffffff",
+  "background_color": "#ffffff",
+  "display": "standalone"
+}

--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,27 @@
+importScripts(
+  "https://storage.googleapis.com/workbox-cdn/releases/5.1.2/workbox-sw.js");
+
+let version = 1;
+
+let item = (path) => {
+  return { url: path, revision: version };
+};
+
+workbox.precaching.precacheAndRoute(
+  [
+    item("/index.html"),
+    item("/privacy.html"),
+    item("/style.css"),
+    item("/app.js"),
+    item("/site.webmanifest"),
+    item("/android-chrome-192x192.png"),
+    item("/android-chrome-512x512.png"),
+    item("/apple-touch-icon.png"),
+    item("/favicon-16x16.png"),
+    item("/favicon-32x32.png"),
+    item("https://plausible.io/js/plausible.js"),
+  ],
+  {
+    ignoreURLParametersMatching: [/.*/]
+  }
+);


### PR DESCRIPTION
Also uses a smaller geographic query for sensors in order to minimize
startup time, both online and from localstorage.

Small nits fixed:

	- adds a <meta name="theme-color"> for full-bleed color
	- sets manifest `start_url` w/ PWA query params
	- adds name/short_name values for homescreen shortcut
	- caches all non-PA assets, including analytics
	- adds MIT license to package.json

To update the site in future, ensure that new assets are added to the
list in `sw.js` and bump the "version" number in that file.

TODO: more aggressive cache busting for the SW impl.