### PR TITLE
Pull full sensor list for privacy

### DIFF
--- a/app.js
+++ b/app.js
@@ -59,15 +59,7 @@
   }
 
   function fetchSensorListAndShowAQI() {
-    // Grab an area around the sensor's coords rather than the full list
-    const offset = 0.125; // In desnse areas, half this is perhaps better
-    const baseDataUrl = `https://www.purpleair.com/data.json`;
-    const nwlat = Math.min(coord.latitude + offset, 90);
-    const selat = Math.max(coord.latitude - offset, -90);
-    const nwlng = Math.min(coord.longitude - offset, 180);
-    const selng = Math.max(coord.longitude + offset, -180);
-    const coordsArgs = `nwlat=${nwlat}&selat=${selat}&nwlng=${nwlng}&selng=${selng}`;
-    const url = `${baseDataUrl}?opt=1/mAQI/a10/cC0&fetch=true&${coordsArgs}&fields=,`;
+    const url = "https://www.purpleair.com/data.json?opt=1/mAQI/a10/cC0&fetch=true&fields=,"
 
     window
       .fetch(url)


### PR DESCRIPTION
As pointed out in https://github.com/skalnik/aqi-wtf/issues/72, we should opt to pull the full sensor list to keep our claim of location privacy. This change was introduced in https://github.com/skalnik/aqi-wtf/pull/70 and was something I tried to implement when I was initially making this, so I got excited to see it working, but I think the privacy implications are more important, so I think the simplified full sensor pull is ideal.

---

Closes #72 