### PR TITLE
change behavior if pm < 0 so app still displays a number and a status

### DIFF
--- a/app.js
+++ b/app.js
@@ -264,7 +264,7 @@
   function aqiFromPM(pm) {
     if (isNaN(pm)) return "-";
     if (pm == undefined) return "-";
-    if (pm < 0) return pm;
+    if (pm < 0) return 0;
     if (pm > 1000) return "-";
 
     if (pm > 350.5) {


### PR DESCRIPTION
Today and last week I've been seeing results like the one mentioned here https://github.com/skalnik/aqi-wtf/pull/60#issuecomment-706265098  
I've attached two images of my own - one from Chrome on a laptop and one from an iPhone.

I've tracked it down to the fact that it's possible to get a pm that's less than 0 (for example, if the AQI is less than .53 and the humidity is very high, which has been true in parts of SF today.)
In that case, the code was returning, and displaying, the pm number (without rounding, because the rounding only happens if `calqAQI` is called), and then on line 113 `getAQIClass` returned undefined because AQI was less than 0, so we didn't get the awesome happy face and green background.

I can't think of any reason why the negative pm should be returned instead of the number a user would understand - 0 - but let me know if I've missed something important! NOTE: I tested my change locally (on line 261 I called `aqiFromPM` with `-.5`) and it worked.

And while I'm here, thanks so much for AQI.wtf! I use it all the time and the smiley face when the AQI is good makes me smile.
Also, this codebase was so easy to read! Much easier to follow than most code I've looked at.
Thanks again.

<img width="1411" alt="AQIWTFscreenshot" src="https://user-images.githubusercontent.com/5827196/128614510-acef0528-303f-41f5-842e-94af329a2b1e.png">

![IMG_5457](https://user-images.githubusercontent.com/5827196/128614540-e92e52cd-9d8a-4626-a7ae-f6ffb93917ad.PNG)


